### PR TITLE
Updated to use python3 and PyObjC 8.4

### DIFF
--- a/customdisplayprofiles
+++ b/customdisplayprofiles
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # customdisplayprofiles
 #
@@ -6,79 +6,37 @@
 # for connected displays.
 #
 # Copyright 2013 Timothy Sutton
-
-from __future__ import print_function
+#
+# python3 revision for macOS 12.3 written by Jonathon Irons, 3/17/2022
 
 import os
-import objc
 import Foundation
 import Quartz
+import ColorSync
 import optparse
 import sys
 
 from pprint import pprint
 
-# - below is bridge metadata of we need of the ColorSync framework
-# - last two arguments of ColorSyncProfileVerify have additional
-#   type_modifier metadata for 'out'-type arguments so that they
-#   can be passed by reference, though this currently does not seem
-#   to function correctly
-objc.parseBridgeSupport("""<?xml version='1.0'?>
-<!DOCTYPE signatures SYSTEM "file://localhost/System/Library/DTDs/BridgeSupport.dtd">
-<signatures version='1.0'>
-    <cftype name='ColorSyncProfileRef' type='^{ColorSyncProfile=}' tollfree='__NSCFType' gettypeid_func='ColorSyncProfileGetTypeID'/>
-    <constant name='kColorSyncDeviceDefaultProfileID' type='^{__CFString=}'/>
-    <constant name='kColorSyncDisplayDeviceClass' type='^{__CFString=}'/>
-    <constant name='kColorSyncProfile' type='^{__CFString=}'/>
-    <constant name='kColorSyncProfileUserScope' type='^{__CFString=}'/>
-    <function name='CGDisplayCreateUUIDFromDisplayID'>
-    <arg type='I'/>
-    <retval already_retained='true' type='^{__CFUUID=}'/>
-    </function>
-    <function name='ColorSyncDeviceCopyDeviceInfo'>
-    <arg type='^{__CFString=}'/>
-    <arg type='^{__CFUUID=}'/>
-    <retval already_retained='true' type='^{__CFDictionary=}'/>
-    </function>
-    <function name='ColorSyncDeviceSetCustomProfiles'>
-    <arg type='^{__CFString=}'/>
-    <arg type='^{__CFUUID=}'/>
-    <arg type='^{__CFDictionary=}'/>
-    <retval type='B'/>
-    </function>
-    <function name='ColorSyncProfileCreateWithURL'>
-    <arg type='^{__CFURL=}'/>
-    <arg type='^^{_CFError}' type_modifier='o'/>
-    <retval already_retained='true' type='^{ColorSyncProfile=}'/>
-    </function>
-    <function name='ColorSyncProfileVerify'>
-    <arg type='^{ColorSyncProfile=}'/>
-    <arg type='^^{_CFError}' type_modifier='o'/>
-    <arg type='^^{_CFError}' type_modifier='o'/>
-    <retval type='B'/>
-    </function>
-</signatures>
-""", globals(), '/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework')
 
-
-def errorExit(msg, code=1):
-    print >> sys.stderr, msg
+def error_exit(msg, code=1):
+    print(sys.stderr, msg)
     sys.exit(code)
 
 
 def verify_profile(profile_url):
     # objc still doesn't seem to know about the CFErrorRefs below
-    profile, create_err = ColorSyncProfileCreateWithURL(profile_url, None)
-    usable, errors, warnings = ColorSyncProfileVerify(profile, None, None)
+    profile, create_err = ColorSync.ColorSyncProfileCreateWithURL(profile_url, None)
+    usable, errors, warnings = ColorSync.ColorSyncProfileVerify(profile, None, None)
 
     if errors:
-        print >> sys.stderr, "Errors verifying profile:"
-        print >> sys.stderr, errors
+        print(sys.stderr, "Errors verifying profile:")
+        print(sys.stderr, errors)
     if warnings:
-        print >> sys.stderr, "Warnings verifying profile:"
-        print >> sys.stderr, warnings
+        print(sys.stderr, "Warnings verifying profile:")
+        print(sys.stderr, warnings)
     if not usable:
-        errorExit("Profile could not be verified!")
+        error_exit("Profile could not be verified!")
 
 
 def main():
@@ -101,14 +59,14 @@ Available actions:
 
     o = optparse.OptionParser(usage=usage)
     o.add_option('-d', '--display', type='int', default=1,
-        help="Display number to target the action given. A value of '1' "
-             "is the default, and means the main display. Second display "
-             "is '2', etc. Verify the numbers using the 'displays' action.")
+                 help="Display number to target the action given. A value of '1' "
+                      "is the default, and means the main display. Second display "
+                      "is '2', etc. Verify the numbers using the 'displays' action.")
     o.add_option('-u', '--user-scope', default=default_user_scope,
-        help="User scope in which to apply the custom profile, when used with the "
-             "'set' action. Either 'any' or 'current'. 'any' requires "
-             "root privileges. Defaults to %s."
-             % (default_user_scope))
+                 help="User scope in which to apply the custom profile, when used with the "
+                      "'set' action. Either 'any' or 'current'. 'any' requires "
+                      "root privileges. Defaults to %s."
+                      % default_user_scope)
     opts, args = o.parse_args()
 
     if len(args) == 0:
@@ -117,9 +75,9 @@ Available actions:
 
     if opts.user_scope:
         if opts.user_scope not in possible_user_scopes:
-            errorExit("--user-scope must be one of: %s" % ", ".join(possible_user_scopes))
+            error_exit("--user-scope must be one of: %s" % ", ".join(possible_user_scopes))
         if opts.user_scope == 'any' and os.getuid() != 0:
-            errorExit("You must have root privileges to modify the any-user scope!")
+            error_exit("You must have root privileges to modify the any-user scope!")
 
     if args[0] not in possible_actions.keys():
         o.print_help()
@@ -130,14 +88,15 @@ Available actions:
     max_displays = 8
     # display list retrieval borrowed from Greg Neagle's mirrortool.py
     # https://gist.github.com/gregneagle/5722568
-    (err, display_ids, 
+    (err, display_ids,
      number_of_online_displays) = Quartz.CGGetOnlineDisplayList(
-                                                    max_displays, None, None)
+        max_displays, None, None)
     if err:
-        errorExit("Error in obtaining online display list: %s" % err)
+        error_exit("Error in obtaining online display list: %s" % err)
 
     # validate --display option
     invalid_display_id = False
+    invalid_msg = ""
     if opts.display <= 0:
         invalid_display_id = True
         invalid_msg = "Display IDs start at 1."
@@ -152,7 +111,7 @@ Available actions:
     if invalid_display_id:
         msg = "--display %s is not valid. " % opts.display
         msg += invalid_msg
-        errorExit(msg)
+        error_exit(msg)
 
     # Some logic to ensure the first display is always the main one, but
     # might confuse things if >2 displays connected.
@@ -167,11 +126,12 @@ Available actions:
 
     displays = []
     for index, display_id in enumerate(display_ids):
-        display = {}
-        display['id'] = display_id
-        display['human_id'] = index + 1
-        display['device_info'] = ColorSyncDeviceCopyDeviceInfo(
-            kColorSyncDisplayDeviceClass, CGDisplayCreateUUIDFromDisplayID(display_id))
+        display = {
+            'id': display_id,
+            'human_id': index + 1,
+            'device_info': ColorSync.ColorSyncDeviceCopyDeviceInfo(
+                ColorSync.kColorSyncDisplayDeviceClass, ColorSync.CGDisplayCreateUUIDFromDisplayID(display_id))
+        }
         displays.append(display)
 
     target_display = displays[opts.display - 1]
@@ -193,13 +153,14 @@ Available actions:
             profile_url = Foundation.kCFNull
         else:
             if len(args) < 2:
-                errorExit("The 'set' action requires a path to an ICC profile as an argument.")
+                error_exit("The 'set' action requires a path to an ICC profile as an argument.")
             profile_path = args[1]
             if not os.path.exists(profile_path):
                 sys.exit("Can't locate profile at path %s!" % profile_path)
             if os.path.isdir(profile_path):
-                errorExit("'%s' is a directory, not a profile!" % profile_path)
-            profile_url = Foundation.CFURLCreateFromFileSystemRepresentation(None, profile_path, len(profile_path), False)
+                error_exit("'%s' is a directory, not a profile!" % profile_path)
+            profile_url = Foundation.CFURLCreateFromFileSystemRepresentation(None, profile_path.encode(),
+                                                                             len(profile_path), False)
             verify_profile(profile_url)
 
         user_scope = eval('Foundation.kCFPreferences%sUser' % opts.user_scope.capitalize())
@@ -207,15 +168,16 @@ Available actions:
         # info on config dict required:
         # /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/Headers/ColorSyncDevice.h
         # http://web.archiveorange.com/archive/print/YwdQZYJTswvvG79VTuyD
-        new_profile_dict = { kColorSyncDeviceDefaultProfileID: profile_url,
-                             kColorSyncProfileUserScope: user_scope }
+        new_profile_dict = {ColorSync.kColorSyncDeviceDefaultProfileID: profile_url,
+                            ColorSync.kColorSyncProfileUserScope: user_scope}
 
-        success = ColorSyncDeviceSetCustomProfiles(
-                    kColorSyncDisplayDeviceClass,
-                    target_display['device_info']['DeviceID'],
-                    new_profile_dict)
+        success = ColorSync.ColorSyncDeviceSetCustomProfiles(
+            ColorSync.kColorSyncDisplayDeviceClass,
+            target_display['device_info']['DeviceID'],
+            new_profile_dict)
         if not success:
-            errorExit("Setting custom profile was unsuccessful!")
+            error_exit("Setting custom profile was unsuccessful!")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Switched print function to Python 3. Added import of ColorSync framework module from pyobjc. Removed import of objc and deprecated parseBridgeSupport code. Cleaned up some formatting using PyCharm.

To get all of the modules to import correctly on my newly updated macOS 12.3 installation, I needed to reinstall pyobjc entirely using:
```
% python3 -m pip freeze | grep pyobjc | while read p; do python3 -m pip uninstall -y "$p"; done;
% sudo python3 -m pip install pyobjc
```

Tested and working with Python 3.8.9 on macOS 12.3 installed on an iMac M1 2021.